### PR TITLE
Fixing issue #128: Default Props Error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -252,9 +252,9 @@ StepWizard.defaultProps = {
 };
 
 export const Step = ({
-    children,
-    isActive,
-    transitions,
+    children = [],
+    isActive = false,
+    transitions = '',
 }) => (
     <div className={`${styles.step} ${transitions} ${isActive ? styles.active : ''}`.trim()}>
         { children }
@@ -268,9 +268,3 @@ if (process.env.NODE_ENV !== 'production') {
         transitions: PropTypes.string,
     };
 }
-
-Step.defaultProps = {
-    children: [],
-    isActive: false,
-    transitions: '',
-};


### PR DESCRIPTION
This PR addresses the issue reported in #128, where a warning is displayed for using `defaultProps` in function components. The warning indicates that support for `defaultProps` will be removed in future major React releases.

Issue was this
![image](https://github.com/user-attachments/assets/727339f6-93bf-4bcc-bb2a-9339413854a8)

### Changes:

1. Replaced the defaultProps with JavaScript default parameters in the function signature of the Step functional component.
2. Ensured proper initialization of default values without altering the component's existing functionality.

### Notes:

- The functionality and behavior of the component remain unchanged.
- This is a refactor aimed at future-proofing the codebase and resolving the deprecation warning.
- Thorough testing has been conducted to confirm that the component behaves as expected after the update.
 
This refactor ensures compatibility with upcoming React updates while addressing the reported issue.